### PR TITLE
Options not properly being sent to the i2c module.

### DIFF
--- a/bmp085.js
+++ b/bmp085.js
@@ -13,7 +13,7 @@ var BMP085 = function (opts) {
     var self = this;
     self.options = _.extend({}, defaultOptions, opts);
     self.events = new EventEmitter();
-    self.wire = new Wire(this.options.address);
+    self.wire = new Wire(this.options.address, {device: this.options.device, debug: this.options.debug});
 
     self.events.on('calibrated', function () {
         self.readData(self.userCallback);


### PR DESCRIPTION
Fixed by passing in the device ID and debug parameters to the i2c module. Before it would only work if the device ID was the system default.
