### PR TITLE
updated package.json i2c dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/fiskeben/bmp085.git"
   },
   "dependencies": {
-    "i2c": "~0.1.4",
+    "i2c": "0.2.x",
     "underscore": "~1.5.2"
   }
 }


### PR DESCRIPTION
Updated I2C dependency to 0.2.x as I was receiving a build error with older dependency.  [Issue #4](https://github.com/fiskeben/bmp085/issues/4).