### PR TITLE
Test callback on calibrate before read

### DIFF
--- a/bmp085.js
+++ b/bmp085.js
@@ -187,7 +187,9 @@ BMP085.prototype.readData = function (callback) {
         self.readPressure(function (rawPressure) {
             var temperature = self.convertTemperature(rawTemperature),
                 pressure = self.convertPressure(rawPressure);
-            callback({'temperature': temperature, 'pressure': pressure});
+            if (callback) {
+                callback({'temperature': temperature, 'pressure': pressure});
+            }
         });
     });
 };


### PR DESCRIPTION
If calibrate is called before read,
then usercallback will not exist and can't be called,
so to prevent exception it's tested before called.

Observed issue was:

  /.../node_modules/bmp085/bmp085.js:190
  callback({temperature: temperature, pressure: pressure});
  TypeError: callback is not a function

Change-Id: If681c2458d82f20e4da22af201c77a217e14a261
Signed-off-by: Philippe Coval <philippe.coval@s-opensource.com>