### PR TITLE
Trap errors in callbacks instead of exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ var BMP085 = require('bmp085'),
     barometer = new BMP085();
 
 barometer.read(function (data) {
-    console.log("Temperature:", data.temperature);
-    console.log("Pressure:", data.pressure);
+    if (data !== null) {
+        console.log("Temperature:", data.temperature);
+        console.log("Pressure:", data.pressure);
+    }
 });
 ```
 

--- a/test.js
+++ b/test.js
@@ -21,7 +21,12 @@ var Bmp085 = require('./bmp085'),
         });
     },
     startTest = function () {
+      try {
         testStandardMode();
+      } catch (err) {
+        console.log("error: " + err);
+        throw (err);
+      }
     };
 
 startTest();


### PR DESCRIPTION
Throw in assync code is not helpful, so instead null data is returned
more refactoring might come later,
as we want to preserve API.

Change-Id: 65f6bc6867aadf9852de18d6c54f968587fa2a9d
Origin: https://github.com/tizenteam/bmp085
Signed-off-by: Philippe Coval <p.coval@samsung.com>